### PR TITLE
Yearly Previews 

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,8 @@ Output:
     "urls": [
         "http://esgf-data.node.example/...",
         "http://esgf-data.node.example/..."
-    ]
+    ],
+    "metadata": {}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ Required Parameters:
 
 Optional Parameters:
   * `variable_id`: override the variable to render in the preview. 
-  * `timestamps`: plot over a list of times. much slower, work in progress 
+  * `timestamps`: plot over a list of times. 
+    * The format should be `start,end` -- two values, comma separated.
+    * Example: `1970,1979`
   * `time_index`: override time index to use. 
 
 
@@ -109,6 +111,8 @@ Optional Parameters:
         * Preserving all other fields, take every third data point from the fields `lat` and `lon`
       * `thin_factor=2&thin_fields=!time,lev`
         * Preserving all other fields, take every other data point from all fields *except* `time` and `lev`. 
+  * `variable_id`:
+    * Which variable to render in the preview. Defaults to `""`. Will attempt to choose the best relevant variable if none is specified.
 
 Output:  
 Returns a job description of the current process, queued to be completed. 

--- a/api/dataset/terarium_hmi.py
+++ b/api/dataset/terarium_hmi.py
@@ -34,7 +34,9 @@ def generate_description(
     return string
 
 
-def enumerate_dataset_skeleton(ds: xarray.Dataset, parent_id: str) -> HMIDataset:
+def enumerate_dataset_skeleton(
+    ds: xarray.Dataset, parent_id: str, variable_id: str = ""
+) -> HMIDataset:
     """
     generates the generic body of the metadata field from a given dataset.
     this function should remain as broadly applicable as possible with the only difference
@@ -48,7 +50,7 @@ def enumerate_dataset_skeleton(ds: xarray.Dataset, parent_id: str) -> HMIDataset
     try:
         start = ds.isel(time=0).time.item().year
         end = ds.isel(time=-1).time.item().year
-        preview = render(ds, timestamps=f"{start},{end}")
+        preview = render(ds, timestamps=f"{start},{end}", variable_index=variable_id)
     except Exception as e:
         preview = f"error creating preview: {e}"
         print(e, flush=True)
@@ -98,6 +100,7 @@ def construct_hmi_dataset(
     parent_dataset_id: str,
     subset_uuid: str,
     opts: DatasetSubsetOptions,
+    variable_id: str = "",
 ) -> HMIDataset:
     """
     generic function for turning a given subset dataset into a terarium-postable request body.

--- a/api/dataset/terarium_hmi.py
+++ b/api/dataset/terarium_hmi.py
@@ -46,7 +46,9 @@ def enumerate_dataset_skeleton(ds: xarray.Dataset, parent_id: str) -> HMIDataset
     note: continues on preview not working with an exception!
     """
     try:
-        preview = render(ds)
+        start = ds.isel(time=0).time.item().year
+        end = ds.isel(time=-1).time.item().year
+        preview = render(ds, timestamps=f"{start},{end}")
     except Exception as e:
         preview = f"error creating preview: {e}"
         print(e, flush=True)

--- a/api/dataset/terarium_hmi.py
+++ b/api/dataset/terarium_hmi.py
@@ -48,7 +48,7 @@ def enumerate_dataset_skeleton(ds: xarray.Dataset, parent_id: str) -> HMIDataset
     try:
         preview = render(ds)
     except Exception as e:
-        preview = ""
+        preview = f"error creating preview: {e}"
         print(e, flush=True)
     hmi_dataset = {
         "userId": "",
@@ -62,9 +62,11 @@ def enumerate_dataset_skeleton(ds: xarray.Dataset, parent_id: str) -> HMIDataset
             "dataStructure": {
                 k: {
                     "attrs": {
-                        ak: ds[k].attrs[ak].item()
-                        if isinstance(ds[k].attrs[ak], numpy.generic)
-                        else ds[k].attrs[ak]
+                        ak: (
+                            ds[k].attrs[ak].item()
+                            if isinstance(ds[k].attrs[ak], numpy.generic)
+                            else ds[k].attrs[ak]
+                        )
                         for ak in ds[k].attrs
                         # _ChunkSizes is an unserializable ndarray, safely ignorable
                         if ak != "_ChunkSizes"
@@ -75,9 +77,11 @@ def enumerate_dataset_skeleton(ds: xarray.Dataset, parent_id: str) -> HMIDataset
                 for k in ds.variables.keys()
             },
             "raw": {
-                k: ds.attrs[k].item()
-                if isinstance(ds.attrs[k], numpy.generic)
-                else ds.attrs[k]
+                k: (
+                    ds.attrs[k].item()
+                    if isinstance(ds.attrs[k], numpy.generic)
+                    else ds.attrs[k]
+                )
                 for k in ds.attrs.keys()
             },
         },

--- a/api/preview/render.py
+++ b/api/preview/render.py
@@ -1,10 +1,10 @@
+import datetime
 import io
 import base64
 from api.search.provider import AccessURLs
 import cartopy.crs as ccrs
 import xarray
 from matplotlib import pyplot as plt
-from typing import List
 from api.dataset.remote import (
     cleanup_potential_artifacts,
     open_dataset,
@@ -21,7 +21,7 @@ def buffer_to_b64_png(buffer: io.BytesIO) -> str:
 
 # handles loading as to not share xarray over rq-worker boundaries
 def render_preview_for_dataset(
-    urls: AccessURLs,
+    dataset: AccessURLs | str,
     variable_index: str = "",
     time_index: str = "",
     timestamps: str = "",
@@ -29,23 +29,22 @@ def render_preview_for_dataset(
 ):
     job_id = kwargs["job_id"]
     try:
-        ds = open_dataset(urls, job_id)
+        ds: xarray.Dataset | None = None
+        # AccessURLs list or UUID str -- UUID str is terarium handle.
+        if isinstance(dataset, list):
+            ds = open_dataset(dataset, job_id)
+        elif isinstance(dataset, str):
+            ds = open_remote_dataset_hmi(dataset, job_id)
+        if timestamps != "":
+            if len(timestamps.split(",")) != 2:
+                return {
+                    "error": f"invalid timestamps '{timestamps}'. ensure it is two timestamps, comma separated"
+                }
         png = render(ds, variable_index, time_index, timestamps)
         cleanup_potential_artifacts(job_id)
-        return {"png": png}
+        return {"previews": png}
     except IOError as e:
         return {"error": f"upstream hosting is likely having a problem. {e}"}
-
-
-def render_preview_for_hmi(uuid: str, **kwargs):
-    job_id = kwargs["job_id"]
-    try:
-        ds = open_remote_dataset_hmi(uuid, job_id)
-        png = render(ds=ds)
-        cleanup_potential_artifacts(job_id)
-        return {"png": png}
-    except IOError as e:
-        return {"error": f"failed with error {e}"}
 
 
 def render(
@@ -54,7 +53,7 @@ def render(
     time_index: str = "",
     timestamps: str = "",
     **kwargs,
-):
+) -> list[dict[str, str]]:
     axes = {}
     for v in ds.variables.keys():
         if "axis" in ds[v].attrs:
@@ -72,7 +71,8 @@ def render(
     if timestamps == "":
         ds = ds.sel({time_index: ds[time_index][0]})
     else:
-        ds = ds.sel({time_index: slice(timestamps.split(","))})
+        ts = [t.strip() for t in timestamps.split(",")]
+        ds = ds.sel({time_index: slice(*ts)})
 
     # we're plotting x, y, time - others need to be shortened to the first element
     print(axes, flush=True)
@@ -87,11 +87,56 @@ def render(
 
     ds = ds[variable_index]
 
-    fig, ax = plt.subplots(subplot_kw={"projection": ccrs.PlateCarree()})
-    ds.plot(transform=ccrs.PlateCarree(), x=axes["X"], y=axes["Y"], add_colorbar=True)
-    ax.coastlines()
+    preview_buffers: list[tuple[str, io.BytesIO]] = []
 
-    buffer = io.BytesIO()
-    plt.savefig(buffer, format="png")
+    def make_plot(data: xarray.Dataset) -> io.BytesIO:
+        fig, ax = plt.subplots(subplot_kw={"projection": ccrs.PlateCarree()})
+        data.plot(
+            ax=ax,
+            transform=ccrs.PlateCarree(),
+            x=axes["X"],
+            y=axes["Y"],
+            add_colorbar=True,
+        )
+        ax.coastlines()
+        buffer = io.BytesIO()
+        plt.savefig(buffer, format="png")
+        return buffer
 
-    return buffer_to_b64_png(buffer)
+    if axes["T"] in ds.dims:
+        # get delta of first two elements to see if it's yearly / monthly / daily
+        delta = ds[axes["T"]][1].item() - ds[axes["T"]][0].item()
+        steps = 0
+        if delta > datetime.timedelta(days=32):
+            steps = 1
+        elif delta > datetime.timedelta(days=1):
+            steps = 12
+        else:
+            steps = 365
+
+        leap_offset = 0
+        last_year = 0
+        # skip by frequency such that index points to head of year
+        for time_i in range(0, len(ds[axes["T"]]), steps):
+            # handle leap years
+            index = time_i + leap_offset
+            if index >= len(ds[axes["T"]]):
+                break
+            year_check = ds.isel({axes["T"]: index})[axes["T"]].item().year
+            if year_check == last_year:
+                leap_offset += 1
+                index += 1
+
+            data = ds.isel({axes["T"]: index})
+            date = data[axes["T"]].item()
+            print(f"rendering: {date}")
+            last_year = date.year
+            preview_buffers.append((date.year, make_plot(data)))
+    else:
+        # single element rather than list
+        year = ds[axes["T"]].item().year
+        print(f"rendering: {year}")
+        preview_buffers.append((year, make_plot(ds)))
+    renders = [{"year": y, "image": buffer_to_b64_png(b)} for (y, b) in preview_buffers]
+    print(f"created {len(renders)} previews", flush=True)
+    return renders

--- a/api/processing/providers/esgf.py
+++ b/api/processing/providers/esgf.py
@@ -55,7 +55,7 @@ def slice_and_store_dataset(
             filters.options_from_url_parameters(params),
         )
         hmi_id = post_hmi_dataset(dataset, filename)
-        return {"status": "ok", "dataset_id": hmi_id}
+        return {"status": "ok", "dataset_id": hmi_id, "filename": filename}
     except Exception as e:
         return {"status": "failed", "error": str(e), "dataset_id": ""}
     finally:

--- a/api/processing/providers/esgf.py
+++ b/api/processing/providers/esgf.py
@@ -22,6 +22,7 @@ def slice_and_store_dataset(
     parent_id: str,
     dataset_id: str,
     params: Dict[str, Any],
+    variable_id: str,
     **kwargs,
 ):
     job_id = kwargs["job_id"]
@@ -53,6 +54,7 @@ def slice_and_store_dataset(
             parent_id,
             job_id,
             filters.options_from_url_parameters(params),
+            variable_id,
         )
         hmi_id = post_hmi_dataset(dataset, filename)
         return {"status": "ok", "dataset_id": hmi_id, "filename": filename}

--- a/api/search/providers/esgf.py
+++ b/api/search/providers/esgf.py
@@ -178,7 +178,7 @@ class ESGFProvider(BaseSearchProvider):
         returns a list of OPENDAP URLs for use in processing given a dataset.
         """
         if dataset_id == "":
-            return []
+            return {}
         self.get_mirrors_for_dataset(dataset_id)
         params = urlencode(
             {

--- a/api/server.py
+++ b/api/server.py
@@ -45,7 +45,8 @@ async def era5_search(query: str = ""):
 @app.get("/fetch/esgf")
 async def esgf_fetch(dataset_id: str):
     urls = esgf.get_all_access_paths_by_id(dataset_id)
-    return {"dataset": dataset_id, "urls": urls}
+    metadata = esgf.get_metadata_for_dataset(dataset_id)
+    return {"dataset": dataset_id, "urls": urls, "metadata": metadata}
 
 
 @app.get(path="/subset/esgf")

--- a/api/server.py
+++ b/api/server.py
@@ -43,20 +43,24 @@ async def era5_search(query: str = ""):
 
 
 @app.get("/fetch/esgf")
-async def esgf_fetch(dataset_id):
+async def esgf_fetch(dataset_id: str):
     urls = esgf.get_all_access_paths_by_id(dataset_id)
     return {"dataset": dataset_id, "urls": urls}
 
 
 @app.get(path="/subset/esgf")
 async def esgf_subset(
-    request: Request, parent_id, dataset_id, redis=Depends(get_redis)
+    request: Request,
+    parent_id: str,
+    dataset_id: str,
+    variable_id: str = "",
+    redis=Depends(get_redis),
 ):
     params = params_to_dict(request)
     urls = esgf.get_all_access_paths_by_id(dataset_id)
     job = create_job(
         func=slice_and_store_dataset,
-        args=[urls, parent_id, dataset_id, params],
+        args=[urls, parent_id, dataset_id, params, variable_id],
         redis=redis,
         queue="subset",
     )
@@ -90,7 +94,7 @@ async def era5_subset(
 @app.get(path="/preview/esgf")
 async def esgf_preview(
     dataset_id: str,
-    variable_index: str = "",
+    variable_id: str = "",
     time_index: str = "",
     timestamps: str = "",
     redis=Depends(get_redis),
@@ -102,7 +106,7 @@ async def esgf_preview(
     )
     job = create_job(
         func=render_preview_for_dataset,
-        args=[dataset, variable_index, time_index, timestamps],
+        args=[dataset, variable_id, time_index, timestamps],
         redis=redis,
         queue="preview",
     )

--- a/api/server.py
+++ b/api/server.py
@@ -9,7 +9,7 @@ from api.dataset.job_queue import create_job, fetch_job_status, get_redis
 from openai import OpenAI
 from urllib.parse import parse_qs
 from typing import List, Dict
-from api.preview.render import render_preview_for_dataset, render_preview_for_hmi
+from api.preview.render import render_preview_for_dataset
 
 app = FastAPI(docs_url="/")
 client = OpenAI()
@@ -88,16 +88,22 @@ async def era5_subset(
 
 
 @app.get(path="/preview/esgf")
-async def esgf_preview(dataset_id: str, redis=Depends(get_redis)):
-    if esgf.is_terarium_hmi_dataset(dataset_id):
-        print("terarium uuid found", flush=True)
-        job = create_job(
-            func=render_preview_for_hmi, args=[dataset_id], redis=redis, queue="preview"
-        )
-        return job
-    else:
-        urls = esgf.get_all_access_paths_by_id(dataset_id)
-        job = create_job(
-            func=render_preview_for_dataset, args=[urls], redis=redis, queue="preview"
-        )
-        return job
+async def esgf_preview(
+    dataset_id: str,
+    variable_index: str = "",
+    time_index: str = "",
+    timestamps: str = "",
+    redis=Depends(get_redis),
+):
+    dataset = (
+        dataset_id
+        if esgf.is_terarium_hmi_dataset(dataset_id)
+        else esgf.get_all_access_paths_by_id(dataset_id)
+    )
+    job = create_job(
+        func=render_preview_for_dataset,
+        args=[dataset, variable_index, time_index, timestamps],
+        redis=redis,
+        queue="preview",
+    )
+    return job

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,13 +10,10 @@ services:
       - ./data:/opt/climate-search/data
     ports:
       - "8000:8000"
-    environment:
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - OPENAI_ORG_ID=${OPENAI_ORG_ID}
-      - TERARIUM_USER=${TERARIUM_USER}
-      - TERARIUM_PASS=${TERARIUM_PASS}
     depends_on:
       - redis
+    env_file:
+      - .env
     entrypoint: [
       "nohup",
       "poetry",
@@ -34,12 +31,7 @@ services:
     volumes:
       - ./api:/opt/climate-search/api
     env_file:
-    - .env
-    environment:
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - OPENAI_ORG_ID=${OPENAI_ORG_ID}
-      - TERARIUM_USER=${TERARIUM_USER}
-      - TERARIUM_PASS=${TERARIUM_PASS}
+      - .env
     depends_on:
       - redis
     entrypoint: [
@@ -53,7 +45,6 @@ services:
       "-u",
       "redis://redis-climate-data:6379" 
     ]
-
   jupyter:
     build:
       context: ./
@@ -63,11 +54,6 @@ services:
       - ./data:/opt/climate-search/data
     ports:
       - "8888:8888"
-    environment:
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - OPENAI_ORG_ID=${OPENAI_ORG_ID}
-      - TERARIUM_USER=${TERARIUM_USER}
-      - TERARIUM_PASS=${TERARIUM_PASS}
     env_file:
       - .env
   # minio:

--- a/env.example
+++ b/env.example
@@ -16,3 +16,4 @@ MINIO_PASS="miniopass"
 MINIO_BUCKET_NAME="climate-data-test-bucket"
 
 TERARIUM_URL="https://server.staging.terarium.ai"
+MIRA_REST_URL="https://mira-rest-url-here-for-dkg.example"


### PR DESCRIPTION
# Yearly Previews

## Considerations

Yearly previews are taken as a snapshot of the first data point for that year. Ideally this could be something like a yearly aggregate or average but this would massively increase the runtime cost and network cost of lazy loading. This should be given thought for how to best handle it. 

## Implementation

Creates year by year previews for subsets and previews with timestamp. 

API Changes: 
Metadata preview field has changed to

```json
{
  "metadata": {
    "preview": {
      [
        {"year": 1850, "image": "base64 string"},
        {"year": 1851, "image": "base64 string"},...
      ]
    }
  }
}
```